### PR TITLE
Fix the import of pykle_serial to avoid startup crash

### DIFF
--- a/KeyboardGenerator/Dialog.py
+++ b/KeyboardGenerator/Dialog.py
@@ -16,14 +16,10 @@ from abc import abstractmethod
 cmdFolder = FreeCAD.ParamGet("User parameter:BaseApp/Preferences/Macro").GetString('MacroPath')
 cmdFolder += os.path.sep + "KeyboardGenerator" + os.path.sep
 
-pykleSerialFolder = cmdFolder  + 'pykle_serial'
-sys.path.append(pykleSerialFolder)
-
 iconFolder = cmdFolder + 'icons' + os.path.sep 
 svgFolder = cmdFolder  + 'svgs' + os.path.sep
 
-# Modules below can only be found after we expand the search path like done above
-import serial 
+from pykle_serial import serial
 import KeyboardQ
 from KeyboardQ import Corner
 import SvgPlateThickness

--- a/KeyboardGenerator/Key.py
+++ b/KeyboardGenerator/Key.py
@@ -1,4 +1,4 @@
-import serial
+from pykle_serial import serial
 import typing
 from enum import Enum
 from typing import List

--- a/KeyboardGenerator/KeyboardQ.py
+++ b/KeyboardGenerator/KeyboardQ.py
@@ -3,7 +3,7 @@ from typing import List, NamedTuple
 from PySide2.QtGui import QPolygonF
 from dataclasses import dataclass
 from functools import cmp_to_key
-import serial
+from pykle_serial import serial
 import typing
 import xml.etree.ElementTree as ET
 import math


### PR DESCRIPTION
With main branch of this macro, if the library pyserial is installed, the macro crashes on startup with an error related to the wrong module being loaded instead of pykle_serial. This PR replaces the unqualified imports with the `from x import y` syntax, and it clears the error for me