### PR TITLE
Get user config path via FreeCAD API

### DIFF
--- a/KeyboardGenerator/Dialog.py
+++ b/KeyboardGenerator/Dialog.py
@@ -382,11 +382,7 @@ def cfgIntToQColor(argb):
 # Reads FreeCADs user configuration file and parses its content to extract
 # The code editors preferences so we can replicate the look.
 def GetUserConfig():
-    freeCadFolder = QtCore.QDir(cmdFolder)
-    freeCadFolder.cdUp()
-    freeCadFolder.cdUp()
-    userCfgPath = freeCadFolder.filePath('user.cfg')
-
+    userCfgPath = os.path.join(FreeCAD.ConfigGet('UserConfigPath'), 'user.cfg')
     tree = ET.parse(userCfgPath)
     root = tree.getroot()
 


### PR DESCRIPTION
FreeCAD 0.20+ adopted the XDG folder structure for Linux. This means that user.cfg is not in the same place. In all cases the FreeCAD API knows where this file is, so the PR just asks it instead of guessing

https://wiki.freecad.org/Release_notes_0.20#Core